### PR TITLE
Change Map.Create() to be generic

### DIFF
--- a/RogueSharp/Map.cs
+++ b/RogueSharp/Map.cs
@@ -765,7 +765,7 @@ namespace RogueSharp
       /// <param name="mapCreationStrategy">A class that implements IMapCreationStrategy and has CreateMap method which defines algorithms for creating interesting Maps</param>
       /// <returns>Map created by calling CreateMap from the specified IMapCreationStrategy</returns>
       /// <exception cref="ArgumentNullException">Thrown on null map creation strategy</exception>
-      public static Map Create( IMapCreationStrategy<Map> mapCreationStrategy )
+      public static T Create<T>( IMapCreationStrategy<T> mapCreationStrategy ) where T : IMap
       {
          if ( mapCreationStrategy == null )
          {


### PR DESCRIPTION
Change Map.Create() to be generic. Returning the same map type as the strategy's map