### PR TITLE
Fix issue in Map.GetCellsInRectangle that caused incorrect cells being returned

### DIFF
--- a/RogueSharp.Test/MapTest.cs
+++ b/RogueSharp.Test/MapTest.cs
@@ -594,6 +594,36 @@ namespace RogueSharp.Test
       }
 
       [TestMethod]
+      public void GetCellsInRectangle_SmallMap_AllCells()
+      {
+         string mapRepresentation = @"#################
+                                      #################
+                                      ##...#######...##
+                                      ##.............##
+                                      ###.###....#...##
+                                      ###...##.#####.##
+                                      ###...##...###..#
+                                      ####............#
+                                      ##############..#
+                                      #################";
+         IMapCreationStrategy<Map> mapCreationStrategy = new StringDeserializeMapCreationStrategy<Map>( mapRepresentation );
+         IMap map = Map.Create( mapCreationStrategy );
+
+         IEnumerable<ICell> cells = map.GetCellsInRectangle( 0, 0, map.Width, map.Height )
+            .OrderBy( c => c.Y )
+            .ThenBy( c => c.X );
+         var actualCells = new StringBuilder();
+         foreach ( ICell cell in cells )
+         {
+            actualCells.Append( cell.ToString() );
+         }
+
+         var expectedCells = mapRepresentation.Replace( " ", string.Empty ).Replace( Environment.NewLine, string.Empty );
+
+         Assert.AreEqual( expectedCells, actualCells.ToString() );
+      }
+
+      [TestMethod]
       public void GetBorderCellsInSquare_SmallMap_ExpectedCells()
       {
          string mapRepresentation = @"#################

--- a/RogueSharp.Test/MapTest.cs
+++ b/RogueSharp.Test/MapTest.cs
@@ -618,7 +618,18 @@ namespace RogueSharp.Test
             actualCells.Append( cell.ToString() );
          }
 
-         var expectedCells = mapRepresentation.Replace( " ", string.Empty ).Replace( Environment.NewLine, string.Empty );
+         var expectedCells = new StringBuilder()
+            .Append( "#################" )
+            .Append( "#################" )
+            .Append( "##...#######...##" )
+            .Append( "##.............##" )
+            .Append( "###.###....#...##" )
+            .Append( "###...##.#####.##" )
+            .Append( "###...##...###..#" )
+            .Append( "####............#" )
+            .Append( "##############..#" )
+            .Append( "#################" )
+            .ToString();
 
          Assert.AreEqual( expectedCells, actualCells.ToString() );
       }

--- a/RogueSharp/Map.cs
+++ b/RogueSharp/Map.cs
@@ -496,9 +496,9 @@ namespace RogueSharp
       public IEnumerable<ICell> GetCellsInRectangle( int top, int left, int width, int height )
       {
          int xMin = Math.Max( 0, left );
-         int xMax = Math.Min( Width - 1, left + width );
+         int xMax = Math.Min( Width, left + width );
          int yMin = Math.Max( 0, top );
-         int yMax = Math.Min( Height - 1, top + height );
+         int yMax = Math.Min( Height, top + height );
 
          for ( int y = yMin; y < yMax; y++ )
          {


### PR DESCRIPTION
Attempting to fetch rectangles containing cells from bottom row or the rightmost column caused incorrect rectangle to be returned. The returned rectangle did not contain cells belonging to the bottom row and/or the right most column.