### PR TITLE
Multi Target .NET Standard 2.0 and .NET 6

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2014 - 2020 Faron Bracy
+Copyright (c) 2014 - 2023 Faron Bracy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ A more interesting way to create a map is to use the `Map` class's static method
 
 MIT License
 
-Copyright (c) 2014 - 2020 Faron Bracy
+Copyright (c) 2014 - 2023 Faron Bracy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/RogueSharp.Test/DijkstraPathFinderTest.cs
+++ b/RogueSharp.Test/DijkstraPathFinderTest.cs
@@ -37,8 +37,8 @@ namespace RogueSharp.Test
          IMapCreationStrategy<Map> mapCreationStrategy = new StringDeserializeMapCreationStrategy<Map>( mapRepresentation );
          IMap map = Map.Create( mapCreationStrategy );
          DijkstraPathFinder dijkstraPathFinder = new DijkstraPathFinder( map );
-         ICell source = null;
-         ICell destination = map.GetCell( 5, 4 );
+         Cell source = null;
+         Cell destination = map.GetCell( 5, 4 );
 
          Path shortestPath = dijkstraPathFinder.ShortestPath( source, destination );
       }
@@ -56,8 +56,8 @@ namespace RogueSharp.Test
          IMapCreationStrategy<Map> mapCreationStrategy = new StringDeserializeMapCreationStrategy<Map>( mapRepresentation );
          IMap map = Map.Create( mapCreationStrategy );
          DijkstraPathFinder dijkstraPathFinder = new DijkstraPathFinder( map );
-         ICell source = map.GetCell( 1, 4 );
-         ICell destination = null;
+         Cell source = map.GetCell( 1, 4 );
+         Cell destination = null;
 
          Path shortestPath = dijkstraPathFinder.ShortestPath( source, destination );
       }
@@ -74,8 +74,8 @@ namespace RogueSharp.Test
          IMapCreationStrategy<Map> mapCreationStrategy = new StringDeserializeMapCreationStrategy<Map>( mapRepresentation );
          IMap map = Map.Create( mapCreationStrategy );
          DijkstraPathFinder dijkstraPathFinder = new DijkstraPathFinder( map );
-         ICell source = map.GetCell( 1, 4 );
-         ICell destination = map.GetCell( 5, 4 );
+         Cell source = map.GetCell( 1, 4 );
+         Cell destination = map.GetCell( 5, 4 );
 
          Path shortestPath = dijkstraPathFinder.ShortestPath( source, destination );
 
@@ -97,8 +97,8 @@ namespace RogueSharp.Test
          IMapCreationStrategy<Map> mapCreationStrategy = new StringDeserializeMapCreationStrategy<Map>( mapRepresentation );
          IMap map = Map.Create( mapCreationStrategy );
          DijkstraPathFinder dijkstraPathFinder = new DijkstraPathFinder( map, 1.41 );
-         ICell source = map.GetCell( 1, 1 );
-         ICell destination = map.GetCell( 6, 4 );
+         Cell source = map.GetCell( 1, 1 );
+         Cell destination = map.GetCell( 6, 4 );
 
          Path shortestPath = dijkstraPathFinder.ShortestPath( source, destination );
 
@@ -122,8 +122,8 @@ namespace RogueSharp.Test
          IMapCreationStrategy<Map> mapCreationStrategy = new StringDeserializeMapCreationStrategy<Map>( mapRepresentation );
          IMap map = Map.Create( mapCreationStrategy );
          DijkstraPathFinder dijkstraPathFinder = new DijkstraPathFinder( map );
-         ICell source = map.GetCell( 0, 1 );
-         ICell destination = map.GetCell( 1, 1 );
+         Cell source = map.GetCell( 0, 1 );
+         Cell destination = map.GetCell( 1, 1 );
 
          dijkstraPathFinder.ShortestPath( source, destination );
       }
@@ -141,8 +141,8 @@ namespace RogueSharp.Test
          IMapCreationStrategy<Map> mapCreationStrategy = new StringDeserializeMapCreationStrategy<Map>( mapRepresentation );
          IMap map = Map.Create( mapCreationStrategy );
          DijkstraPathFinder dijkstraPathFinder = new DijkstraPathFinder( map );
-         ICell source = map.GetCell( 1, 1 );
-         ICell destination = map.GetCell( 0, 1 );
+         Cell source = map.GetCell( 1, 1 );
+         Cell destination = map.GetCell( 0, 1 );
 
          dijkstraPathFinder.ShortestPath( source, destination );
       }
@@ -160,8 +160,8 @@ namespace RogueSharp.Test
          IMapCreationStrategy<Map> mapCreationStrategy = new StringDeserializeMapCreationStrategy<Map>( mapRepresentation );
          IMap map = Map.Create( mapCreationStrategy );
          DijkstraPathFinder dijkstraPathFinder = new DijkstraPathFinder( map );
-         ICell source = map.GetCell( 1, 1 );
-         ICell destination = map.GetCell( 6, 1 );
+         Cell source = map.GetCell( 1, 1 );
+         Cell destination = map.GetCell( 6, 1 );
 
          dijkstraPathFinder.ShortestPath( source, destination );
       }
@@ -178,8 +178,8 @@ namespace RogueSharp.Test
          IMapCreationStrategy<Map> mapCreationStrategy = new StringDeserializeMapCreationStrategy<Map>( mapRepresentation );
          IMap map = Map.Create( mapCreationStrategy );
          DijkstraPathFinder dijkstraPathFinder = new DijkstraPathFinder( map );
-         ICell source = map.GetCell( 1, 4 );
-         ICell destination = map.GetCell( 5, 4 );
+         Cell source = map.GetCell( 1, 4 );
+         Cell destination = map.GetCell( 5, 4 );
 
          Path shortestPath = dijkstraPathFinder.TryFindShortestPath( source, destination );
 
@@ -201,8 +201,8 @@ namespace RogueSharp.Test
          IMapCreationStrategy<Map> mapCreationStrategy = new StringDeserializeMapCreationStrategy<Map>( mapRepresentation );
          IMap map = Map.Create( mapCreationStrategy );
          DijkstraPathFinder dijkstraPathFinder = new DijkstraPathFinder( map, 1.41 );
-         ICell source = map.GetCell( 1, 1 );
-         ICell destination = map.GetCell( 6, 4 );
+         Cell source = map.GetCell( 1, 1 );
+         Cell destination = map.GetCell( 6, 4 );
 
          Path shortestPath = dijkstraPathFinder.TryFindShortestPath( source, destination );
 
@@ -226,8 +226,8 @@ namespace RogueSharp.Test
          IMapCreationStrategy<Map> mapCreationStrategy = new StringDeserializeMapCreationStrategy<Map>( mapRepresentation );
          IMap map = Map.Create( mapCreationStrategy );
          DijkstraPathFinder dijkstraPathFinder = new DijkstraPathFinder( map );
-         ICell source = null;
-         ICell destination = map.GetCell( 5, 4 );
+         Cell source = null;
+         Cell destination = map.GetCell( 5, 4 );
 
          Path shortestPath = dijkstraPathFinder.TryFindShortestPath( source, destination );
       }
@@ -245,8 +245,8 @@ namespace RogueSharp.Test
          IMapCreationStrategy<Map> mapCreationStrategy = new StringDeserializeMapCreationStrategy<Map>( mapRepresentation );
          IMap map = Map.Create( mapCreationStrategy );
          DijkstraPathFinder dijkstraPathFinder = new DijkstraPathFinder( map );
-         ICell source = map.GetCell( 1, 4 );
-         ICell destination = null;
+         Cell source = map.GetCell( 1, 4 );
+         Cell destination = null;
 
          Path shortestPath = dijkstraPathFinder.TryFindShortestPath( source, destination );
       }
@@ -263,8 +263,8 @@ namespace RogueSharp.Test
          IMapCreationStrategy<Map> mapCreationStrategy = new StringDeserializeMapCreationStrategy<Map>( mapRepresentation );
          IMap map = Map.Create( mapCreationStrategy );
          DijkstraPathFinder dijkstraPathFinder = new DijkstraPathFinder( map );
-         ICell source = map.GetCell( 0, 1 );
-         ICell destination = map.GetCell( 1, 1 );
+         Cell source = map.GetCell( 0, 1 );
+         Cell destination = map.GetCell( 1, 1 );
 
          Path shortestPath = dijkstraPathFinder.TryFindShortestPath( source, destination );
 
@@ -283,8 +283,8 @@ namespace RogueSharp.Test
          IMapCreationStrategy<Map> mapCreationStrategy = new StringDeserializeMapCreationStrategy<Map>( mapRepresentation );
          IMap map = Map.Create( mapCreationStrategy );
          DijkstraPathFinder dijkstraPathFinder = new DijkstraPathFinder( map );
-         ICell source = map.GetCell( 1, 1 );
-         ICell destination = map.GetCell( 0, 1 );
+         Cell source = map.GetCell( 1, 1 );
+         Cell destination = map.GetCell( 0, 1 );
 
          Path shortestPath = dijkstraPathFinder.TryFindShortestPath( source, destination );
 
@@ -303,8 +303,8 @@ namespace RogueSharp.Test
          IMapCreationStrategy<Map> mapCreationStrategy = new StringDeserializeMapCreationStrategy<Map>( mapRepresentation );
          IMap map = Map.Create( mapCreationStrategy );
          DijkstraPathFinder dijkstraPathFinder = new DijkstraPathFinder( map );
-         ICell source = map.GetCell( 1, 1 );
-         ICell destination = map.GetCell( 6, 1 );
+         Cell source = map.GetCell( 1, 1 );
+         Cell destination = map.GetCell( 6, 1 );
 
          Path shortestPath = dijkstraPathFinder.TryFindShortestPath( source, destination );
 
@@ -316,8 +316,8 @@ namespace RogueSharp.Test
       {
          IMapCreationStrategy<Map> mapCreationStrategy = new StringDeserializeMapCreationStrategy<Map>( Algorithms.TestSetup.TestHelpers.Map200x400 );
          IMap map = Map.Create( mapCreationStrategy );
-         ICell source = map.GetCell( 5, 1 );
-         ICell destination = map.GetCell( 29, 187 );
+         Cell source = map.GetCell( 5, 1 );
+         Cell destination = map.GetCell( 29, 187 );
          DijkstraPathFinder dijkstraPathFinder = new DijkstraPathFinder( map );
 
          Path shortestPath = dijkstraPathFinder.TryFindShortestPath( source, destination );
@@ -340,8 +340,8 @@ namespace RogueSharp.Test
             int y1 = randomY.Next( 399 );
             int x2 = randomX.Next( 199 );
             int y2 = randomY.Next( 399 );
-            ICell source = map.GetCell( x1, y1 );
-            ICell destination = map.GetCell( x2, y2 );
+            Cell source = map.GetCell( x1, y1 );
+            Cell destination = map.GetCell( x2, y2 );
 
             Stopwatch timer = Stopwatch.StartNew();
 
@@ -382,8 +382,8 @@ namespace RogueSharp.Test
             int y1 = randomY.Next( 399 );
             int x2 = randomX.Next( 199 );
             int y2 = randomY.Next( 399 );
-            ICell source = map.GetCell( x1, y1 );
-            ICell destination = map.GetCell( x2, y2 );
+            Cell source = map.GetCell( x1, y1 );
+            Cell destination = map.GetCell( x2, y2 );
 
             Stopwatch timer = Stopwatch.StartNew();
             
@@ -423,8 +423,8 @@ namespace RogueSharp.Test
             int y1 = 1;
             int x2 = randomX.Next( 199 );
             int y2 = randomY.Next( 399 );
-            ICell source = map.GetCell( x1, y1 );
-            ICell destination = map.GetCell( x2, y2 );
+            Cell source = map.GetCell( x1, y1 );
+            Cell destination = map.GetCell( x2, y2 );
 
             Stopwatch timer = Stopwatch.StartNew();
 

--- a/RogueSharp.Test/RogueSharp.Test.csproj
+++ b/RogueSharp.Test/RogueSharp.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/RogueSharp/Algorithms/AStarShortestPath.cs
+++ b/RogueSharp/Algorithms/AStarShortestPath.cs
@@ -37,7 +37,7 @@ namespace RogueSharp.Algorithms
       /// <param name="source">The source Cell to find a shortest path from</param>
       /// <param name="destination">The destination Cell to find a shortest path to</param>
       /// <param name="map">The Map on which to find the shortest path between Cells</param>
-      /// <returns>List of Cells representing a shortest path from the specified source to the specified destination</returns>
+      /// <returns>List of Cells representing a shortest path from the specified source to the specified destination. If no path is found null will be returned</returns>
       public List<TCell> FindPath( TCell source, TCell destination, IMap<TCell> map )
       {
          // OPEN = the set of nodes to be evaluated

--- a/RogueSharp/Algorithms/DijkstraShortestPath.cs
+++ b/RogueSharp/Algorithms/DijkstraShortestPath.cs
@@ -125,7 +125,7 @@ namespace RogueSharp.Algorithms
       /// Returns an IEnumerable of DirectedEdges representing a shortest path from the sourceVertex to the specified destinationVertex
       /// </summary>
       /// <param name="destinationVertex">The destination vertex to find a shortest path to</param>
-      /// <returns>IEnumerable of DirectedEdges representing a shortest path from the sourceVertex to the specified destinationVertex</returns>
+      /// <returns>IEnumerable of DirectedEdges representing a shortest path from the sourceVertex to the specified destinationVertex. If no path is found null will be returned</returns>
       public IEnumerable<DirectedEdge> PathTo( int destinationVertex )
       {
          if ( !HasPathTo( destinationVertex ) )

--- a/RogueSharp/Algorithms/DirectedEdge.cs
+++ b/RogueSharp/Algorithms/DirectedEdge.cs
@@ -22,17 +22,17 @@
       /// <summary>
       /// Returns the destination vertex of the DirectedEdge
       /// </summary>
-      public int From { get; private set; }
+      public int From { get; set; }
 
       /// <summary>
       /// Returns the start vertex of the DirectedEdge
       /// </summary>
-      public int To { get; private set; }
+      public int To { get; set; }
 
       /// <summary>
       /// Returns the weight of the DirectedEdge
       /// </summary>
-      public double Weight { get; private set; }
+      public double Weight { get; set; }
 
       /// <summary>
       /// Returns a string that represents the current DirectedEdge

--- a/RogueSharp/Cell.cs
+++ b/RogueSharp/Cell.cs
@@ -90,7 +90,7 @@
       /// </summary>
       /// <param name="other">The Cell to compare this instance to</param>
       /// <returns>True if the instances are equal; False otherwise</returns>
-      public bool Equals( ICell other )
+      public virtual bool Equals( ICell other )
       {
          if ( ReferenceEquals( null, other ) )
          {

--- a/RogueSharp/DijkstraPathFinder.cs
+++ b/RogueSharp/DijkstraPathFinder.cs
@@ -61,12 +61,12 @@ namespace RogueSharp
          {
             if ( cell.IsWalkable )
             {
-               int v = IndexFor( cell );
+               int v = _map.IndexFor( cell );
                foreach ( TCell neighbor in _map.GetAdjacentCells( cell.X, cell.Y ) )
                {
                   if ( neighbor.IsWalkable )
                   {
-                     int w = IndexFor( neighbor );
+                     int w = _map.IndexFor( neighbor );
                      _graph.AddEdge( new DirectedEdge( v, w, 1.0 ) );
                      _graph.AddEdge( new DirectedEdge( w, v, 1.0 ) );
                   }
@@ -93,12 +93,12 @@ namespace RogueSharp
          {
             if ( cell.IsWalkable )
             {
-               int v = IndexFor( cell );
+               int v = _map.IndexFor( cell );
                foreach ( TCell neighbor in _map.GetAdjacentCells( cell.X, cell.Y, true ) )
                {
                   if ( neighbor.IsWalkable )
                   {
-                     int w = IndexFor( neighbor );
+                     int w = _map.IndexFor( neighbor );
                      if ( neighbor.X != cell.X && neighbor.Y != cell.Y )
                      {
                         _graph.AddEdge( new DirectedEdge( v, w, diagonalCost ) );
@@ -123,7 +123,7 @@ namespace RogueSharp
       /// <exception cref="ArgumentNullException">Thrown when source or destination is null</exception>
       /// <exception cref="PathNotFoundException">Thrown when there is not a path from the source to the destination</exception>
       /// <returns>Returns a shortest Path containing a list of Cells from a specified source Cell to a destination Cell</returns>
-      public Path ShortestPath( ICell source, ICell destination )
+      public Path ShortestPath( TCell source, TCell destination )
       {
          Path shortestPath = TryFindShortestPath( source, destination );
 
@@ -142,7 +142,7 @@ namespace RogueSharp
       /// <param name="destination">The Cell which is at the end of the path</param>
       /// <exception cref="ArgumentNullException">Thrown when source or destination is null</exception>
       /// <returns>Returns a shortest Path containing a list of Cells from a specified source Cell to a destination Cell. If no path is found null will be returned</returns>
-      public Path TryFindShortestPath( ICell source, ICell destination )
+      public Path TryFindShortestPath( TCell source, TCell destination )
       {
          if ( source == null )
          {
@@ -162,19 +162,19 @@ namespace RogueSharp
          return new Path( cells );
       }
 
-      private IEnumerable<ICell> ShortestPathCells( ICell source, ICell destination )
+      private IEnumerable<ICell> ShortestPathCells( TCell source, TCell destination )
       {
          IEnumerable<DirectedEdge> path;
-         int sourceIndex = IndexFor( source );
+         int sourceIndex = _map.IndexFor( source );
          if ( _sourceIndex.HasValue && _sourceIndex == sourceIndex && _dijkstraShortestPath != null )
          {
-            path = _dijkstraShortestPath.PathTo( IndexFor( destination ) );
+            path = _dijkstraShortestPath.PathTo( _map.IndexFor( destination ) );
          }
          else
          {
             _sourceIndex = sourceIndex;
             _dijkstraShortestPath = new DijkstraShortestPath( _graph, sourceIndex );
-            path = _dijkstraShortestPath.PathTo( IndexFor( destination ) );
+            path = _dijkstraShortestPath.PathTo( _map.IndexFor( destination ) );
          }
 
          if ( path == null )
@@ -186,22 +186,9 @@ namespace RogueSharp
             yield return source;
             foreach ( DirectedEdge edge in path )
             {
-               yield return CellFor( edge.To );
+               yield return _map.CellFor( edge.To );
             }
          }
-      }
-
-      private int IndexFor( ICell cell )
-      {
-         return ( cell.Y * _map.Width ) + cell.X;
-      }
-
-      private ICell CellFor( int index )
-      {
-         int x = index % _map.Width;
-         int y = index / _map.Width;
-
-         return _map.GetCell( x, y );
       }
    }
 }

--- a/RogueSharp/Map.cs
+++ b/RogueSharp/Map.cs
@@ -198,7 +198,7 @@ namespace RogueSharp
       /// <param name="y">Y location of the Cell to set properties on, starting with 0 as the top</param>
       /// <param name="isTransparent">True if line-of-sight is not blocked by this Cell. False otherwise</param>
       /// <param name="isWalkable">True if a character could walk across the Cell normally. False otherwise</param>
-      public void SetCellProperties( int x, int y, bool isTransparent, bool isWalkable )
+      public virtual void SetCellProperties( int x, int y, bool isTransparent, bool isWalkable )
       {
          _cells[x, y].IsTransparent = isTransparent;
          _cells[x, y].IsWalkable = isWalkable;
@@ -207,7 +207,7 @@ namespace RogueSharp
       /// <summary>
       /// Sets the properties of all Cells in the Map to be transparent and walkable
       /// </summary>
-      public void Clear()
+      public virtual void Clear()
       {
          Clear( true, true );
       }
@@ -217,7 +217,7 @@ namespace RogueSharp
       /// </summary>
       /// <param name="isTransparent">Optional parameter defaults to true if not provided. True if line-of-sight is not blocked by this Cell. False otherwise</param>
       /// <param name="isWalkable">Optional parameter defaults to true if not provided. True if a character could walk across the Cell normally. False otherwise</param>
-      public void Clear( bool isTransparent, bool isWalkable )
+      public virtual void Clear( bool isTransparent, bool isWalkable )
       {
          foreach ( TCell cell in GetAllCells() )
          {
@@ -247,7 +247,7 @@ namespace RogueSharp
       /// Copies the Cell properties of a smaller source Map into this destination Map at location (0,0)
       /// </summary>
       /// <param name="sourceMap">An IMap which must be of smaller size and able to fit in this destination Map at the specified location</param>
-      public void Copy( IMap<TCell> sourceMap )
+      public virtual void Copy( IMap<TCell> sourceMap )
       {
          Copy( sourceMap, 0, 0 );
       }
@@ -260,7 +260,7 @@ namespace RogueSharp
       /// <param name="top">Optional parameter defaults to 0 if not provided. Y location of the Cell to start copying parameters to, starting with 0 as the top</param>
       /// <exception cref="ArgumentNullException">Thrown on null source map</exception>
       /// <exception cref="ArgumentException">Thrown on invalid source map dimensions</exception>
-      public void Copy( IMap<TCell> sourceMap, int left, int top )
+      public virtual void Copy( IMap<TCell> sourceMap, int left, int top )
       {
          if ( sourceMap == null )
          {

--- a/RogueSharp/RogueSharp.csproj
+++ b/RogueSharp/RogueSharp.csproj
@@ -17,11 +17,11 @@
    * Added A* shortest path algorithm
  Breaking changes:
    * Bug fix - Change Map.Create to be generic, returning the same map type as the creation strategy's map. (Thanks to Andre Odendaal)
-   * Bug fix - Update Map Save and Restore methods to track IsExplored status. (Thanks to Andre Odendaal)
    * Map.Initialize is virtual so that it can be overridden in derived classes
    * Map.Clone is now virtual and generic so that it can be overridden in derived classes.
    * Removed IsInFov from Map and Cell classes (use FieldOfView class instead)
    * Removed IsExplored from Map and Cell classes
+   * Multi target .NET Standard 2.0 and .NET 6
     </Description>
     <PackageReleaseNotes>
  A .NET Standard class library providing map generation, path-finding, and field-of-view utilities frequently used in roguelikes or 2D tile based games. Inspired by libtcod
@@ -35,13 +35,13 @@
    * Added A* shortest path algorithm
  Breaking changes:
    * Bug fix - Change Map.Create to be generic, returning the same map type as the creation strategy's map. (Thanks to Andre Odendaal)
-   * Bug fix - Update Map Save and Restore methods to track IsExplored status. (Thanks to Andre Odendaal)
    * Map.Initialize is virtual so that it can be overridden in derived classes
    * Map.Clone is now virtual and generic so that it can be overridden in derived classes.
    * Removed IsInFov from Map and Cell classes (use FieldOfView class instead)
    * Removed IsExplored from Map and Cell classes
+   * Multi target .NET Standard 2.0 and .NET 6
     </PackageReleaseNotes>
-    <Copyright>Copyright 2014-2020 Faron Bracy</Copyright>
+    <Copyright>Copyright 2014-2023 Faron Bracy</Copyright>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/FaronBracy/RogueSharp</PackageProjectUrl>
     <RepositoryUrl>https://github.com/FaronBracy/RogueSharp.git</RepositoryUrl>

--- a/RogueSharp/RogueSharp.csproj
+++ b/RogueSharp/RogueSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <Version>5.0.0-pre4</Version>
     <Authors>Faron Bracy</Authors>
     <Company />


### PR DESCRIPTION
Multi-Target .NET Standard 2.0 and .NET 6

https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-1-0#when-to-target-net50-or-net60-vs-netstandard

> Most widely used libraries will multi-target for both .NET Standard 2.0 and .NET 5+. Supporting .NET Standard 2.0 gives you the most reach, while supporting .NET 5+ ensures you can leverage the latest platform features for customers that are already on .NET 5+.